### PR TITLE
suggested changes

### DIFF
--- a/Code/GraphMol/Descriptors/DCLV.h
+++ b/Code/GraphMol/Descriptors/DCLV.h
@@ -22,6 +22,7 @@
 #include <Geometry/point.h>
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/export.h>
+#include <boost/dynamic_bitset.hpp>
 
 namespace RDKit {
 namespace Descriptors {
@@ -48,6 +49,7 @@ class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
   bool includeLigand = true;
   double probeRadius = 1.4;
   int confId = -1;
+  double maxRadius = 1.87;
 
   DoubleCubicLatticeVolume(const ROMol &mol, bool isProtein = false,
                            bool includeLigand = true, double probeRadius = 1.2,
@@ -67,20 +69,23 @@ class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
   double getSurfaceArea();
 
   /*! \return Polar Surface Area */
-  double getPolarSurfaceArea(const bool &includeSandP);
+  double getPolarSurfaceArea(bool includeSandP);
+
+  /*! \return Surface Area from specified atoms */
+  double getPartialSurfaceArea(const boost::dynamic_bitset<> &polarAtoms);
 
   /*! \return Solvent Accessible Surface Area for specified atom */
-  double getAtomSurfaceArea(const unsigned int &atom_idx);
-  
+  double getAtomSurfaceArea(unsigned int atomIdx);
+
   /*! \return Volume for specified atom */
-  double getAtomVolume(const unsigned int &atom_idx, const double &solventRadius);
-  
+  double getAtomVolume(unsigned int atomIdx, double solventRadius);
+
   /*! \return Volume bound by probe sphere */
   double getVolume();
-  
+
   /*! \return van der Waals Volume */
-  double getVDWVolume(); 
-  
+  double getVDWVolume();
+
   /*! \return Compactness of the protein */
   double getCompactness();
 
@@ -88,9 +93,8 @@ class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
   double getPackingDensity();
 
   /*! \return Set of Points representing the surface */
-  
-  private:
-  
+
+ private:
   // used by methods
   unsigned int numAtoms = 0;
   std::vector<RDGeom::Point3D> positions;
@@ -105,8 +109,8 @@ class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
   double vdwVolume = 0.0;
 
   // helpers
-  bool testPoint(double *vect, const double &solvrad, const std::vector<unsigned int> &nbrs);
-
+  bool testPoint(const RDGeom::Point3D &vect, double solvrad,
+                 const std::vector<unsigned int> &nbrs);
 };
 }  // namespace Descriptors
 }  // namespace RDKit

--- a/Code/GraphMol/Descriptors/DCLV_dots.h
+++ b/Code/GraphMol/Descriptors/DCLV_dots.h
@@ -8,14 +8,17 @@
 /* BSD license, which is included in the file                      */
 /* license.txt.                                                    */
 /*=================================================================*/
+#pragma once
 
 // set of standard dots for computing the DCLV values
 // based on a 320 faced polyhedron
+#include <Geometry/point.h>
 
 double standardArea = 12.3298;
 double dotArea = 0.03853087;
 
-static double standardDots[320][3] = {
+// clang-format off
+static const RDGeom::Point3D standardDots[320] = {
 {-0.577350f, -0.577350f, -0.577350f},
 {-0.448278f, -0.547076f, -0.706934f},
 {-0.706934f, -0.448278f, -0.547076f},
@@ -337,3 +340,4 @@ static double standardDots[320][3] = {
 {0.798035f, 0.449997f, 0.400803f},
 {0.816797f, 0.559125f, 0.142204f}
 };
+// clang-format on


### PR DESCRIPTION
A set of suggested changes to make this more "RDKit like"

The changes are mostly stylistic and include things like:
- simple data types like ints and doubles are passed by value instead of const reference : there's no need to use a reference here and we don't normally declare arguments that are copied as const.
- simplify/shorten code by making more use of the RDKit Point3D type
- clang-format was run over everything
- added a function to allow client code to specify which atoms should be included in the surface area calculation; this should also be exposed to Python.

I'm sure you've seen this already, but the expected values from the existing tests need to be updated. I didn't want to do this since I know that you and Roger are still looking at the code.

We do need tests of the new functionality before merging the final PR


